### PR TITLE
Tests: fix tests

### DIFF
--- a/crates/parser/src/grammar/expr.rs
+++ b/crates/parser/src/grammar/expr.rs
@@ -56,6 +56,8 @@ fn expr_binding_power(p: &mut Parser, minimum_binding_power: u8) -> Option<Compl
         }
     }
 
+    p.clear_expected();
+
     Some(lhs)
 }
 
@@ -504,7 +506,7 @@ Root@0..7
                     LParen@0..1 "("
                     VariableRef@1..4
                       Ident@1..4 "foo"
-                [31mParse Error[0m: at 1..4, expected [33m+[0m, [33m-[0m, [33m*[0m, [33m/[0m, [33m>[0m, [33m>=[0m, [33m<[0m, [33m<=[0m, [33mor[0m, [33mand[0m, [33m==[0m or [33m)[0m"#]],
+                [31mParse Error[0m: at 1..4, expected [33m)[0m"#]],
         );
     }
 
@@ -663,7 +665,7 @@ Root@0..28
                         Whitespace@13..14 " "
                         Literal@14..15
                           Number@14..15 "1"
-                [31mParse Error[0m: at 14..15, expected [33m.[0m, [33m+[0m, [33m-[0m, [33m*[0m, [33m/[0m, [33m>[0m, [33m>=[0m, [33m<[0m, [33m<=[0m, [33mor[0m, [33mand[0m, [33m==[0m, [33m+[0m, [33m-[0m, [33m*[0m, [33m/[0m, [33m>[0m, [33m>=[0m, [33m<[0m, [33m<=[0m, [33mor[0m, [33mand[0m, [33m==[0m or [33m}[0m"#]],
+                [31mParse Error[0m: at 14..15, expected [33m}[0m"#]],
         );
     }
 
@@ -847,7 +849,7 @@ Root@0..23
                       Whitespace@20..21 " "
                       Literal@21..23
                         Number@21..23 "10"
-                [31mParse Error[0m: at 21..23, expected [33m.[0m, [33m+[0m, [33m-[0m, [33m*[0m, [33m/[0m, [33m>[0m, [33m>=[0m, [33m<[0m, [33m<=[0m, [33mor[0m, [33mand[0m, [33m==[0m, [33m,[0m, [33m)[0m, [33mnumber[0m, [33mstring[0m, [33mboolean[0m, [33midentifier[0m, [33m-[0m, [33mnot[0m, [33m([0m, [33mcall[0m or [33m{[0m"#]],
+                [31mParse Error[0m: at 21..23, expected [33m,[0m, [33m)[0m, [33mnumber[0m, [33mstring[0m, [33mboolean[0m, [33midentifier[0m, [33m-[0m, [33mnot[0m, [33m([0m, [33mcall[0m or [33m{[0m"#]],
         );
     }
 

--- a/crates/parser/src/grammar/stmt.rs
+++ b/crates/parser/src/grammar/stmt.rs
@@ -155,19 +155,19 @@ Root@0..13
         check(
             "if true or false",
             expect![[r#"
-            Root@0..16
-              Error@0..16
-                IfKw@0..2 "if"
-                Whitespace@2..3 " "
-                InfixExpr@3..16
-                  Literal@3..8
-                    Boolean@3..7 "true"
-                    Whitespace@7..8 " "
-                  OrKw@8..10 "or"
-                  Whitespace@10..11 " "
-                  Literal@11..16
-                    Boolean@11..16 "false"
-            [31mParse Error[0m: at 11..16, expected [33m+[0m, [33m-[0m, [33m*[0m, [33m/[0m, [33m>[0m, [33m>=[0m, [33m<[0m, [33m<=[0m, [33mor[0m, [33mand[0m, [33m==[0m, [33m+[0m, [33m-[0m, [33m*[0m, [33m/[0m, [33m>[0m, [33m>=[0m, [33m<[0m, [33m<=[0m, [33mor[0m, [33mand[0m, [33m==[0m or [33m{[0m"#]],
+                Root@0..16
+                  Error@0..16
+                    IfKw@0..2 "if"
+                    Whitespace@2..3 " "
+                    InfixExpr@3..16
+                      Literal@3..8
+                        Boolean@3..7 "true"
+                        Whitespace@7..8 " "
+                      OrKw@8..10 "or"
+                      Whitespace@10..11 " "
+                      Literal@11..16
+                        Boolean@11..16 "false"
+                [31mParse Error[0m: at 11..16, expected [33m{[0m"#]],
         );
     }
 
@@ -176,25 +176,25 @@ Root@0..13
         check(
             "if { let x = 5 }",
             expect![[r#"
-            Root@0..16
-              Error@0..16
-                IfKw@0..2 "if"
-                Whitespace@2..3 " "
-                CodeBlock@3..16
-                  LBrace@3..4 "{"
-                  Whitespace@4..5 " "
-                  VariableDef@5..15
-                    LetKw@5..8 "let"
-                    Whitespace@8..9 " "
-                    Ident@9..10 "x"
-                    Whitespace@10..11 " "
-                    Equals@11..12 "="
-                    Whitespace@12..13 " "
-                    Literal@13..15
-                      Number@13..14 "5"
-                      Whitespace@14..15 " "
-                  RBrace@15..16 "}"
-            [31mParse Error[0m: at 15..16, expected [33m+[0m, [33m-[0m, [33m*[0m, [33m/[0m, [33m>[0m, [33m>=[0m, [33m<[0m, [33m<=[0m, [33mor[0m, [33mand[0m, [33m==[0m or [33m{[0m"#]],
+                Root@0..16
+                  Error@0..16
+                    IfKw@0..2 "if"
+                    Whitespace@2..3 " "
+                    CodeBlock@3..16
+                      LBrace@3..4 "{"
+                      Whitespace@4..5 " "
+                      VariableDef@5..15
+                        LetKw@5..8 "let"
+                        Whitespace@8..9 " "
+                        Ident@9..10 "x"
+                        Whitespace@10..11 " "
+                        Equals@11..12 "="
+                        Whitespace@12..13 " "
+                        Literal@13..15
+                          Number@13..14 "5"
+                          Whitespace@14..15 " "
+                      RBrace@15..16 "}"
+                [31mParse Error[0m: at 15..16, expected [33m{[0m"#]],
         )
     }
 
@@ -305,27 +305,27 @@ Root@0..13
         check(
             "if true {} else if {}",
             expect![[r#"
-            Root@0..21
-              If@0..21
-                IfKw@0..2 "if"
-                Whitespace@2..3 " "
-                Literal@3..8
-                  Boolean@3..7 "true"
-                  Whitespace@7..8 " "
-                CodeBlock@8..11
-                  LBrace@8..9 "{"
-                  RBrace@9..10 "}"
-                  Whitespace@10..11 " "
-                ElseIf@11..21
-                  ElseKw@11..15 "else"
-                  Whitespace@15..16 " "
-                  Error@16..21
-                    IfKw@16..18 "if"
-                    Whitespace@18..19 " "
-                    CodeBlock@19..21
-                      LBrace@19..20 "{"
-                      RBrace@20..21 "}"
-            [31mParse Error[0m: at 20..21, expected [33m+[0m, [33m-[0m, [33m*[0m, [33m/[0m, [33m>[0m, [33m>=[0m, [33m<[0m, [33m<=[0m, [33mor[0m, [33mand[0m, [33m==[0m or [33m{[0m"#]],
+                Root@0..21
+                  If@0..21
+                    IfKw@0..2 "if"
+                    Whitespace@2..3 " "
+                    Literal@3..8
+                      Boolean@3..7 "true"
+                      Whitespace@7..8 " "
+                    CodeBlock@8..11
+                      LBrace@8..9 "{"
+                      RBrace@9..10 "}"
+                      Whitespace@10..11 " "
+                    ElseIf@11..21
+                      ElseKw@11..15 "else"
+                      Whitespace@15..16 " "
+                      Error@16..21
+                        IfKw@16..18 "if"
+                        Whitespace@18..19 " "
+                        CodeBlock@19..21
+                          LBrace@19..20 "{"
+                          RBrace@20..21 "}"
+                [31mParse Error[0m: at 20..21, expected [33m{[0m"#]],
         );
     }
 
@@ -353,7 +353,7 @@ Root@0..13
                         Whitespace@18..19 " "
                         Literal@19..24
                           Boolean@19..24 "false"
-                [31mParse Error[0m: at 19..24, expected [33m+[0m, [33m-[0m, [33m*[0m, [33m/[0m, [33m>[0m, [33m>=[0m, [33m<[0m, [33m<=[0m, [33mor[0m, [33mand[0m, [33m==[0m or [33m{[0m"#]],
+                [31mParse Error[0m: at 19..24, expected [33m{[0m"#]],
         )
     }
 
@@ -394,7 +394,7 @@ Root@0..13
                             Whitespace@34..35 " "
                             Literal@35..36
                               Number@35..36 "5"
-                [31mParse Error[0m: at 35..36, expected [33m.[0m, [33m+[0m, [33m-[0m, [33m*[0m, [33m/[0m, [33m>[0m, [33m>=[0m, [33m<[0m, [33m<=[0m, [33mor[0m, [33mand[0m, [33m==[0m or [33m}[0m"#]],
+                [31mParse Error[0m: at 35..36, expected [33m}[0m"#]],
         )
     }
 
@@ -518,7 +518,7 @@ Root@0..13
                           Whitespace@25..26 " "
                           Literal@26..27
                             Number@26..27 "5"
-                [31mParse Error[0m: at 26..27, expected [33m.[0m, [33m+[0m, [33m-[0m, [33m*[0m, [33m/[0m, [33m>[0m, [33m>=[0m, [33m<[0m, [33m<=[0m, [33mor[0m, [33mand[0m, [33m==[0m or [33m}[0m"#]],
+                [31mParse Error[0m: at 26..27, expected [33m}[0m"#]],
         )
     }
 

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -91,6 +91,10 @@ impl<'t, 'input> Parser<'t, 'input> {
         self.peek().is_none()
     }
 
+    pub(crate) fn clear_expected(&mut self) {
+        self.expected_kinds.clear();
+    }
+
     // FIXME
     //
     // Sometimes (particularly with variable assignments),


### PR DESCRIPTION
Fix tests

Now that there are lots of tokens associated with expressions, we should probably rewrite `ParseError` to allow descriptive errors instead of just `expected` vs `actual` token types.

